### PR TITLE
increase max iterations for the ratings algo to 200

### DIFF
--- a/lib/icu_ratings/tournament.rb
+++ b/lib/icu_ratings/tournament.rb
@@ -126,7 +126,7 @@ module ICU
       end
       if version >= 3
         # See http://ratings.icu.ie/articles/18 (Part 3)
-        max_iterations = [50, 50]
+        max_iterations = [200, 200]
       end
 
       # Phase 1.


### PR DESCRIPTION
This was previously upped from 30 to 50 in 2013
https://ratings.icu.ie/articles/18

However 50 was not enough to converge for the
Ulster leagues rounds 7-13, 2019. 200 iterations seems to work instead.

When it was bumped before, Mark decided to treat this as a new version
of the rating system (Version 1.3). I don't think that is necessary
here: it's an implementation detail and all previous results would be
rated the same way with 200 iterations as with 50.